### PR TITLE
Nastavení lokálního vývoje pro docker

### DIFF
--- a/app/config/config.ci.local.neon
+++ b/app/config/config.ci.local.neon
@@ -6,7 +6,7 @@ parameters:
         password:
 
     skautIS:
-        appId: skaut_is_app_id
+        appId: 31153c75-6c74-49ab-8660-123786a11a3b
         test: true
 
 

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -13,6 +13,7 @@ Allow from all
 
     RewriteCond %{HTTPS} !=on
     RewriteCond %{HTTP_HOST} !=localhost
+    RewriteCond %{HTTP_HOST} !=srs.loc
     RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
 	# prevents files starting with dot to be viewed by browser


### PR DESCRIPTION
- nastavil jsem nové skautis AppID pro docker
- vypnul jsem https redirect pro lokální vývoj na adrese srs.loc

Pro použití je potřeba si nastavit v etc/hosts směrování výchozí docker IP na srs.loc 
U mně například takto:
`192.168.99.100         srs.loc`

PS: 
Pro přístup do databáze na dockeru jsou údaje:
hostname: mysql
username: root
password: 
name: srs