### PR TITLE
Exporty

### DIFF
--- a/app/AdminModule/Components/GroupsGridControl.php
+++ b/app/AdminModule/Components/GroupsGridControl.php
@@ -66,6 +66,10 @@ class GroupsGridControl extends Control
         $grid->setItemsPerPageList([25, 50, 100, 250, 500]);
         $grid->setStrictSessionFilterValues(false);
 
+	$stamp=date("Y-m-d H.m.s");
+	$grid->addExportCsv("Export všech", "NSJ2023 Skupiny$stamp.csv");
+	$grid->addExportCsvFiltered("Export vyfiltrovaných", "NSJ2023 Skupiny fi $stamp.csv");
+
         $grid->addGroupAction('Export seznamu skupin')
             ->onSelect[] = [$this, 'groupExportUsers'];
 

--- a/app/AdminModule/Components/GroupsGridControl.php
+++ b/app/AdminModule/Components/GroupsGridControl.php
@@ -23,6 +23,7 @@ use Ublaboo\DataGrid\Exception\DataGridColumnStatusException;
 use Ublaboo\DataGrid\Exception\DataGridException;
 
 use function count;
+use function date;
 
 /**
  * Komponenta pro zobrazení datagridu družin.
@@ -66,9 +67,9 @@ class GroupsGridControl extends Control
         $grid->setItemsPerPageList([25, 50, 100, 250, 500]);
         $grid->setStrictSessionFilterValues(false);
 
-	$stamp=date("Y-m-d H.m.s");
-	$grid->addExportCsv("Export všech", "NSJ2023 Skupiny$stamp.csv");
-	$grid->addExportCsvFiltered("Export vyfiltrovaných", "NSJ2023 Skupiny fi $stamp.csv");
+        $stamp = date('Y-m-d H.m.s');
+        $grid->addExportCsv('admin.common.export_all', 'NSJ2023 Skupiny ' . $stamp . 'csv');
+        $grid->addExportCsvFiltered('admin.common.export_filter', 'NSJ2023 Skupiny fi ' . $stamp . 'csv');
 
         $grid->addGroupAction('Export seznamu skupin')
             ->onSelect[] = [$this, 'groupExportUsers'];

--- a/app/AdminModule/Components/PatrolsGridControl.php
+++ b/app/AdminModule/Components/PatrolsGridControl.php
@@ -65,6 +65,10 @@ class PatrolsGridControl extends Control
         $grid->setItemsPerPageList([25, 50, 100, 250, 500]);
         $grid->setStrictSessionFilterValues(false);
 
+        $stamp=date("Y-m-d H.m.s");
+        $grid->addExportCsv("Export všech", "NSJ2023 Druziny $stamp.csv");
+        $grid->addExportCsvFiltered("Export vyfiltrovaných", "NSJ2023 Druziny fi $stamp.csv");
+
         $grid->addGroupAction('Export seznamu družin')
             ->onSelect[] = [$this, 'groupExportUsers'];
 

--- a/app/AdminModule/Components/PatrolsGridControl.php
+++ b/app/AdminModule/Components/PatrolsGridControl.php
@@ -22,6 +22,7 @@ use Ublaboo\DataGrid\Exception\DataGridColumnStatusException;
 use Ublaboo\DataGrid\Exception\DataGridException;
 
 use function count;
+use function date;
 
 /**
  * Komponenta pro zobrazení datagridu družin.
@@ -65,9 +66,9 @@ class PatrolsGridControl extends Control
         $grid->setItemsPerPageList([25, 50, 100, 250, 500]);
         $grid->setStrictSessionFilterValues(false);
 
-        $stamp=date("Y-m-d H.m.s");
-        $grid->addExportCsv("Export všech", "NSJ2023 Druziny $stamp.csv");
-        $grid->addExportCsvFiltered("Export vyfiltrovaných", "NSJ2023 Druziny fi $stamp.csv");
+        $stamp = date('Y-m-d H.m.s');
+        $grid->addExportCsv('admin.common.export_all', 'NSJ2023 Druziny ' . $stamp . 'csv');
+        $grid->addExportCsvFiltered('admin.common.export_filter', 'NSJ2023 Druziny fi ' . $stamp . 'csv');
 
         $grid->addGroupAction('Export seznamu družin')
             ->onSelect[] = [$this, 'groupExportUsers'];

--- a/app/AdminModule/Presenters/templates/Users/groups.latte
+++ b/app/AdminModule/Presenters/templates/Users/groups.latte
@@ -1,4 +1,8 @@
 {block main}
+
     <h2>Skupiny</h2>
+    <style>
+        .datagrid-exports::before { content: "{_admin.common.export_note}"}
+    </style>
     {control groupsGrid}
 {/block}

--- a/app/AdminModule/Presenters/templates/Users/patrols.latte
+++ b/app/AdminModule/Presenters/templates/Users/patrols.latte
@@ -1,4 +1,7 @@
 {block main}
     <h2>Družiny</h2>
+    <style>
+        .datagrid-exports::before { content: "{_admin.common.export_note}"}
+    </style>
     {control patrolsGrid}
 {/block}

--- a/app/lang/admin.cs_CZ.neon
+++ b/app/lang/admin.cs_CZ.neon
@@ -32,6 +32,10 @@ common:
     role_option: "{0} %role% (%count% uživatelů)|{1} %role% (%count% uživatel)|[2,4] %role% (%count% uživatelé)|[5,Inf[ %role% (%count% uživatelů)"
     subevent_option: "{0} %subevent% (%count% uživatelů)|{1} %subevent% (%count% uživatel)|[2,4] %subevent% (%count% uživatelé)|[5,Inf[ %subevent% (%count% uživatelů)"
 
+    export_note: "Exportují se všechny řádky nebo ty právě zobrazené. Sloupce viz tlačítko vpravo."
+    export_all: "Export všech"
+    export_filter: "Export zobrazených"
+
 menu:
     dashboard: "Úvod"
     cms: "Web"


### PR DESCRIPTION
Jednodušší implementace exportů(CSV). Škoda, že jsem to neprozkoumal dřív, narazil jsem na vestavěnou funkci exportu DataGridu před týdnem. Asi toho neumí tolik, a využívá vždy aktuální pohled na datagridu (sloupce a řazení) a všechny řádeky nebo ty filtrované přes filtrační řádek (ale v překladu to nazývám zobrazené), než to  udělám  přes ten Services\ExcelExport

Nevím, jak se to chová při vyšším počtu záznamů (>25 ), jsem rád když si v testovcím skautisu přihlásím 2 oddíly,  protože blansko je zablokované :(

(je tam přidaná textová poznámka nalevo od tlačítek,  těžkopádně přes CSS ::before {content:-...}, šlo by to nějak přes tooltip bez zasahování do šablon nebo skriptů ? (Případně jde smazat v admin.lang.neon ~ řádek export_note )
